### PR TITLE
fix(lint): use fmt.Fprintf instead of WriteString(fmt.Sprintf(...))

### DIFF
--- a/internal/formatter/text.go
+++ b/internal/formatter/text.go
@@ -30,23 +30,23 @@ func FormatText(documents []*usfm.Document) (string, error) {
 
 		// Document header
 		if doc.MainTitle != "" {
-			result.WriteString(fmt.Sprintf("%s\n", doc.MainTitle))
+			fmt.Fprintf(&result, "%s\n", doc.MainTitle)
 			result.WriteString(strings.Repeat("-", len(doc.MainTitle)) + "\n\n")
 		}
 
 		if doc.ID != "" {
-			result.WriteString(fmt.Sprintf("Book: %s\n", doc.ID))
+			fmt.Fprintf(&result, "Book: %s\n", doc.ID)
 		}
 
 		if doc.Header != "" {
-			result.WriteString(fmt.Sprintf("Header: %s\n", doc.Header))
+			fmt.Fprintf(&result, "Header: %s\n", doc.Header)
 		}
 
 		result.WriteString("\n")
 
 		// Chapters
 		for _, chapter := range doc.Chapters {
-			result.WriteString(fmt.Sprintf("Chapter %d\n", chapter.Number))
+			fmt.Fprintf(&result, "Chapter %d\n", chapter.Number)
 			result.WriteString(strings.Repeat("-", 20) + "\n\n")
 
 			// Sections
@@ -54,17 +54,17 @@ func FormatText(documents []*usfm.Document) (string, error) {
 				if section.Title != "" {
 					// Add indent based on section level
 					indent := strings.Repeat("  ", section.Level-1)
-					result.WriteString(fmt.Sprintf("%s%s\n", indent, section.Title))
+					fmt.Fprintf(&result, "%s%s\n", indent, section.Title)
 
 					if section.Reference != "" {
-						result.WriteString(fmt.Sprintf("%s(%s)\n", indent, section.Reference))
+						fmt.Fprintf(&result, "%s(%s)\n", indent, section.Reference)
 					}
 					result.WriteString("\n")
 				}
 
 				// Verses
 				for _, verse := range section.Verses {
-					result.WriteString(fmt.Sprintf("%d. %s", verse.Number, verse.Text))
+					fmt.Fprintf(&result, "%d. %s", verse.Number, verse.Text)
 
 					// Add footnotes
 					if len(verse.Footnotes) > 0 {
@@ -73,8 +73,8 @@ func FormatText(documents []*usfm.Document) (string, error) {
 							if j > 0 {
 								result.WriteString("; ")
 							}
-							result.WriteString(fmt.Sprintf("%s:%s - %s",
-								footnote.Caller, footnote.Reference, footnote.Text))
+							fmt.Fprintf(&result, "%s:%s - %s",
+								footnote.Caller, footnote.Reference, footnote.Text)
 						}
 						result.WriteString("]")
 					}

--- a/internal/formatter/tsv.go
+++ b/internal/formatter/tsv.go
@@ -49,7 +49,7 @@ func FormatTSV(documents []*usfm.Document) (string, error) {
 					footnotesField := cleanTSVField(strings.Join(footnotes, "; "))
 
 					// Write TSV row
-					result.WriteString(fmt.Sprintf("%s\t%d\t%d\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(&result, "%s\t%d\t%d\t%s\t%s\t%s\t%s\t%s\n",
 						bookID,
 						chapter.Number,
 						verse.Number,
@@ -58,7 +58,7 @@ func FormatTSV(documents []*usfm.Document) (string, error) {
 						verseText,
 						footnotesField,
 						references,
-					))
+					)
 				}
 			}
 		}


### PR DESCRIPTION
## Why

The `Lint` job on `master` started failing without any source change.

`.github/workflows` pins golangci-lint to `latest`, which now resolves to **v2.12.2**. Its staticcheck enables **QF1012**, flagging `WriteString(fmt.Sprintf(...))` on a `strings.Builder`.

Evidence this is linter drift, not a regression:

- `internal/formatter/text.go` last modified **2025-08-06**
- `master` CI was **green on 2025-09-22** against that same source
- The next run (today) picked up a newer linter and went red

## What

CI reported only 3 findings because golangci-lint caps duplicates at `max-same-issues=3`. There were **9** in total across both formatters — fixing only the reported 3 would have surfaced the remaining 6 on the next run. All 9 are converted.

| File | Occurrences |
|---|---|
| `internal/formatter/text.go` | 8 |
| `internal/formatter/tsv.go` | 1 |

## Verification

- `golangci-lint run` with the **exact CI version (v2.12.2)** → `0 issues`
- `go build ./...`, `go vet ./...` clean
- `go test ./...` passes, including `internal/formatter`

Output is byte-for-byte identical — `fmt.Fprintf(&result, f, a...)` and `result.WriteString(fmt.Sprintf(f, a...))` produce the same bytes; only the intermediate string allocation is dropped.

## Worth considering separately

The root cause is the floating `latest` pin. It will do this again the next time staticcheck adds a rule. Pinning golangci-lint to an explicit version would make CI reproducible.