### PR TITLE
ci: pin golangci-lint instead of tracking latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,12 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:
-        version: latest
+        # Pinned deliberately. With `latest`, the linter floats while the source
+        # stands still, so a green master turns red on a commit that touches no Go
+        # code: staticcheck enabled QF1012 in v2.12.2 and the next unrelated PR ate
+        # the failure. Bump this on purpose, so the rule churn lands in a commit
+        # that is about the rule churn.
+        version: v2.12.2
         args: --timeout=5m
 
   build:


### PR DESCRIPTION
Follow-up to #18, which fixed the QF1012 findings. This removes the reason they showed up when they did.

The lint job resolved `version: latest`, so the linter floated while the source stood still. `internal/formatter/text.go` was last modified in **August 2025** and master was **green in September 2025** against byte-identical code. The same code failed this week purely because `latest` had become **v2.12.2**, whose staticcheck enables QF1012.

The failure then landed on an unrelated dependency bump, which is the wrong place to be reading a linter changelog.

Pinning does not avoid the work, it just moves it somewhere legible: bumping the version becomes a deliberate commit whose diff is exactly the rule churn it causes, rather than an ambush on whoever pushes next. `v2.12.2` is what master is currently green against.

Worth knowing: the CI report is also truncated by default. It printed 3 QF1012 findings while the tree actually had 9, because `max-same-issues` defaults to 3. Fixing only what CI showed would have re-failed on the next run with the remaining 6.